### PR TITLE
Catch filemtime warning thrown as ErrorException

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -85,7 +85,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
 
         try {
             $reader->getClassAnnotations($reflectionClass);
-        } catch (AnnotationException $e) {
+        } catch (AnnotationException | \ErrorException $e) {
             /*
              * Ignore any AnnotationException to not break the cache warming process if an Annotation is badly
              * configured or could not be found / read / etc.
@@ -99,14 +99,14 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         foreach ($reflectionClass->getMethods() as $reflectionMethod) {
             try {
                 $reader->getMethodAnnotations($reflectionMethod);
-            } catch (AnnotationException $e) {
+            } catch (AnnotationException | \ErrorException $e) {
             }
         }
 
         foreach ($reflectionClass->getProperties() as $reflectionProperty) {
             try {
                 $reader->getPropertyAnnotations($reflectionProperty);
-            } catch (AnnotationException $e) {
+            } catch (AnnotationException | \ErrorException $e) {
             }
         }
     }


### PR DESCRIPTION
In `Doctrine\Common\Annotations\PsrCachedReader::getLastModification` when `ReflectionClass->getFileName()` returns a filename containing `eval()'d`, the call to `filemtime` l.198 emits a warning which is thrown as an Error Exception in Symfony by default and kills the cache warming process.

| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.4 or 6.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
